### PR TITLE
Change "id" to "word" to match the Cassandra schema

### DIFF
--- a/src/main/scala/com/datastax/powertools/analytics/SimpleSparkStreaming.scala
+++ b/src/main/scala/com/datastax/powertools/analytics/SimpleSparkStreaming.scala
@@ -108,8 +108,8 @@ object SimpleSparkStreaming {
 
 
 //case classes are used to map the data to DSE tables
-case class Event(id: String, count: Long, time: Long)
-case class EventRollup(id: String, count: Long)
+case class Event(word: String, count: Long, time: Long)
+case class EventRollup(word: String, count: Long)
 
 //because we are checkpointing the data into DSEFS, we need to register the case classes with kryo
 class MyRegistrator extends KryoRegistrator {


### PR DESCRIPTION
Currently it will error out when running the spark streaming job.  When I changed "id" to "word" it matched the schema and was able to write to the rollups table.